### PR TITLE
Update env_taxa_correlation.R

### DIFF
--- a/R/env_taxa_correlation.R
+++ b/R/env_taxa_correlation.R
@@ -44,7 +44,7 @@ taxa.env.correlation <- function(physeq, grouping_column, method="pearson", pval
 
   method<- match.arg(method,c("pearson", "kendall", "spearman"),several.ok = F)
 
-  abund_table <- otu_table(physeq)
+  abund_table <- t(otu_table(physeq))
   meta_table <- data.frame(sample_data(physeq))
   #get grouping information
   groups<-meta_table[,grouping_column]


### PR DESCRIPTION
Line 59 has a "filtering" on rownames(mt_env) [i.e. the samples] but abund_table was created by otu_table(physeq) giving out an OTUxSamples table and not a SamplexOTU (at least in my case, not doing the compelte pipeline inside microbiomeSeq). Transposing the table can solve the problem and the error arising